### PR TITLE
`setup` -> `setup_method`

### DIFF
--- a/ghcontribs/tests/test_contrib.py
+++ b/ghcontribs/tests/test_contrib.py
@@ -18,7 +18,7 @@ class TestContribType:
 
 
 class TestGitHubContrib:
-    def setup(self):
+    def setup_method(self):
         self.contribs = {
             'pull': GitHubContrib(
                 owner='openpathsampling',


### PR DESCRIPTION
Pytest prefers (and now, apparently requires) the use of `setup_method` instead of `setup`.